### PR TITLE
github: release helm chart only on new git tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,6 @@
 name: Create and publish a Docker image
 on:
   push:
-    branches:
-      - 'master'
     tags:
       - 'v*'
 


### PR DESCRIPTION
helm chart must be release only when a new tag is created.